### PR TITLE
chore: Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "openssl"]
 	path = openssl
 	url = https://github.com/openssl/openssl
+	shallow = true


### PR DESCRIPTION
Make openssl as shallow clone submodule, avoid it gets unnecessarily big dragging all that history.